### PR TITLE
php 7.2 compatible

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -12,7 +12,7 @@
 namespace light\hashids;
 
 use Hashids\Hashids as BaseHashids;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * This is a wrapper for Hashids.


### PR DESCRIPTION
fixed PHP Compile Error 'yii\base\ErrorException' with message 'Cannot use 'Object' as class name as it is reserved'